### PR TITLE
Add the fourth orientation

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ If one or more parameter is missing, the current time will be used.
 
 **Parameters:**
 
-- `orientation` (int): Orientation value (0-2). Default: 0
+- `orientation` (int): Orientation value (0-3). Default: 0
 
 ---
 

--- a/commands.py
+++ b/commands.py
@@ -170,7 +170,7 @@ def set_fun_mode(value=False):
 def set_orientation(orientation=0):
     """Set the orientation of the device."""
     orientation = to_int(orientation, "orientation")
-    validate_range(orientation, 0, 2, "Orientation")
+    validate_range(orientation, 0, 3, "Orientation")
     return bytes.fromhex("05000680") + bytes.fromhex(int_to_hex(orientation))
 
 


### PR DESCRIPTION
I found that the `set_orientation` command was missing the fourth orientation. I made the necessary changes to add the option. Tested working with 32x32 led matrix from Action.