### PR TITLE
Add support for variable-width fonts

### DIFF
--- a/src/pypixelcolor/commands/send_text.py
+++ b/src/pypixelcolor/commands/send_text.py
@@ -271,7 +271,7 @@ def _split_image_into_chunks(img: Image.Image, chunk_width: int) -> list[Image.I
         chunk_width (int): Width of each chunk in pixels.
 
     Returns:
-        list[Image.Image]: List of image chunks.
+        list[Image.Image]: List of image chunks, all with width=chunk_width (padded with black if needed).
     """
     width, height = img.size
     chunks = []
@@ -282,9 +282,19 @@ def _split_image_into_chunks(img: Image.Image, chunk_width: int) -> list[Image.I
 
         # Crop the chunk from the image
         chunk = img.crop((x, 0, x + actual_width, height))
-        chunks.append(chunk)
 
-        logger.debug(f"Created chunk {len(chunks)}: {actual_width}x{height} pixels at x={x}")
+        # If this chunk is narrower than chunk_width, pad it with black pixels
+        if actual_width < chunk_width:
+            # Create a new image with the full chunk_width, filled with black (0)
+            padded_chunk = Image.new('L', (chunk_width, height), 0)
+            # Paste the actual chunk on the left side
+            padded_chunk.paste(chunk, (0, 0))
+            chunk = padded_chunk
+            logger.debug(f"Created chunk {len(chunks)}: {actual_width}x{height} pixels (padded to {chunk_width}x{height}) at x={x}")
+        else:
+            logger.debug(f"Created chunk {len(chunks)}: {actual_width}x{height} pixels at x={x}")
+
+        chunks.append(chunk)
 
     return chunks
 


### PR DESCRIPTION
This change adds support for variable-width fonts. The purpose is majorly for scrolling text (animation 1 and animation 2). Instead of rendering each character individually, it renders the whole string and splits it into chunks.

`pypixelcolor -a <ADDR> -c send_text "Hello World" var_width=True animation=1 font=/System/Library/Fonts/Supplemental/Arial.ttf`

prints Hello World in variable font width scrolling from left to right.
Since the iPixel display expects for the right to left animation (2) the characters to be send in reverse order, i added the rtl=true option which reverses the order of sent chunks.

`pypixelcolor -a <ADDR> -c send_text "Hello World" var_width=True animation=2 rtl=true font=/System/Library/Fonts/Supplemental/Arial.ttf`

also arabic text does work now

`pypixelcolor -a <ADDR> -c send_text "مرحبا بالعالم" var_width=True animation=2 rtl=true font=/System/Library/Fonts/Supplemental/Arial.ttf

https://github.com/user-attachments/assets/a5cbc774-3ea7-4bc7-817d-2f388fb52431


